### PR TITLE
Suffix automaton2 Compatibility with end position sizes

### DIFF
--- a/content/strings/SuffixAutomaton.h
+++ b/content/strings/SuffixAutomaton.h
@@ -27,8 +27,8 @@ struct SuffixAutomaton {
 				int q = a[p].next[c];
 				if (a[p].len + 1 == a[q].len) a[cur].link = q;
 				else {
-					a.push_back(a[q]);
-					a.back().len = a[p].len + 1;
+					a.push_back({a[p].len+1, a[q].pos, 0, a[q].link, 
+						a[q].next});
 					for(; p >= 0 && a[p].next[c] == q; p = a[p].link)
 						a[p].next[c] = sz(a)-1;
 					a[q].link = a[cur].link = sz(a)-1;

--- a/content/strings/SuffixAutomaton2.h
+++ b/content/strings/SuffixAutomaton2.h
@@ -2,9 +2,7 @@
  * Author: Sachin Sivakumar
  * Date: 2025-01-24
  * Description: Adds endpos (number of occurrences of substring),
- * to and from (number of paths to and from node), suffadj (reversed 
- * suffix link graph), topnext and toplink (topsort of nodes
- * by transition and suffix links).
+ * to and from (number of paths to and from node), topsort of nodes
  * Status: works but not stress tested
  */
 #pragma once
@@ -12,31 +10,19 @@
 int endpos; ll to, from = 1; // add to end of st
 a[last].endpos++; // add to end of char loop
 // add to Suffix Automaton
-vi topnext, toplink; vvi suffadj;
+vi topsort;
 // add to end of constructor
-suffadj.resize(sz(a));
-rep(u, 1, sz(a)) suffadj[a[u].link].push_back(u);
-vi seen(sz(a));
-auto dfs = [&](int u, auto &&dfs) {
-	if(seen[u]) return;
-	seen[u] = true;
+vvi buckets(sz(a));
+rep(u, 0, sz(a)) buckets[a[u].len].push_back(u);
+rep(i, 0, sz(buckets))
+	for(int u : buckets[i]) topsort.push_back(u);
+for(int i = sz(a)-1; i >= 0; i--) {
+	int u = topsort[i];
 	for(auto [c, v] : a[u].next)
-		dfs(v, dfs), a[u].from += a[v].from;
-	topnext.push_back(u);
-};
-dfs(0, dfs);
-seen = vi(sz(a));
-auto dfs1 = [&](int u, auto &&dfs1) {
-	if(seen[u]) return;
-	seen[u] = true;
-	for(int v : suffadj[u]) dfs1(v, dfs1);
-	toplink.push_back(u);
-};
-dfs1(0, dfs1);
-rep(i, 0, sz(a)-1) 
-	a[a[toplink[i]].link].endpos += a[toplink[i]].endpos;
-reverse(all(topnext)), reverse(all(toplink));
+		a[u].from += a[v].from;
+	if(u) a[a[u].link].endpos += a[u].endpos;
+}
 a[0].to = 1;
-for(int u : topnext)
+for(int u : topsort)
 	for(auto [c, v] : a[u].next)
 		a[v].to += a[u].to;


### PR DESCRIPTION
### Summary
The natural way to add end position sizes to SuffixAutomaton.h would be problematic with the current method since it copies the size when cloning, which it shouldn't do. I didn't catch this earlier because I thought SuffixAutomaton2 was the only set of changes to the automaton I made at that time but it wasn't true. I've checked now and this should be the only changes needed.

### Submission Link/Screenshots
![image](https://github.com/user-attachments/assets/d844d3c2-5907-43ea-a31e-d871e03f2e12)
The standard sliding window Suffix Automaton Problem

### Checklist
- [x] AC on at least 1 problem
- [x] Using tabs for indentation
- [ ] Longest line at most 63 characters (with tab length 2)
  - however its fine in the pdf (i checked)
