### PR TITLE
fix double import of suffix automaton

### DIFF
--- a/content/strings/chapter.tex
+++ b/content/strings/chapter.tex
@@ -12,5 +12,5 @@
 \kactlimport{HashInterval.h}
 \kactlimport{AhoCorasick.h}
 \kactlimport{LyndonFactorization.h}
-\kactlimport{SuffixAutomaton.h}
+% \kactlimport{SuffixAutomaton.h}
 % \kactlimport{SuffixAutomaton2.h}


### PR DESCRIPTION
### Summary
`SuffixAutomaton.h` gets imported once after `SuffixArray.h` and again at the end:
```tex
\kactlimport{SuffixArray.h}
\kactlimport{SuffixAutomaton.h} % !
\kactlimport{SuffixTree.h}
\kactlimport{Hashing.h}
\kactlimport{HashInterval.h}
\kactlimport{AhoCorasick.h}
\kactlimport{LyndonFactorization.h}
\kactlimport{SuffixAutomaton.h} % !
```

### Checklist
- [ ] ~~AC on at least 1 problem~~ (N/A)
- [x] Using tabs for indentation
- [x] Longest line at most 63 characters (with tab length 2)
